### PR TITLE
Fix stdout redirection

### DIFF
--- a/gekko/gk_solver_extension.py
+++ b/gekko/gk_solver_extension.py
@@ -1,4 +1,3 @@
-import sys
 from abc import ABC, abstractmethod
 from typing import List
 
@@ -53,8 +52,6 @@ def solve_with_converter(self, converter, disp=True):
     if self._remote:
         print("WARNING: Remote solve not supported by solver extension; defaulted to local solve.")
         self._remote = False
-    
-    c.setup_stdout_redirect(disp)
 
     # setup solver
     c.set_solver()
@@ -63,7 +60,7 @@ def solve_with_converter(self, converter, disp=True):
     c.set_options()
 
     # solve the model
-    c.solve()
+    c.solve(disp)
 
     # store the results back into the gekko model
     c.store()
@@ -108,7 +105,7 @@ class GKConverter(ABC):
         pass
 
     @abstractmethod
-    def solve(self) -> None:
+    def solve(self, disp=True) -> None:
         pass
 
     @abstractmethod
@@ -249,22 +246,6 @@ class GKConverter(ABC):
             "type": obj_type,
             "parameters": obj_parameters
         })
-    
-
-    def setup_stdout_redirect(self, disp):
-        # direct stdout to a file
-        self._output_file = open(self._gekko_model._path + "/output.txt", "w")
-        if disp:
-            sys.stdout = OutputRedirector(sys.stdout, self._output_file)
-        else:
-            # dont display output on console
-            sys.stdout = OutputRedirector(self._output_file)
-        
-    
-    def solve_complete(self):
-        # tear down stdout redirect
-        sys.stdout = sys.__stdout__
-        self._output_file.close()
 
 
     def handle_status(self, status_dict, status, status_string) -> None:

--- a/gekko/gk_solver_extension_pyomo.py
+++ b/gekko/gk_solver_extension_pyomo.py
@@ -1,5 +1,6 @@
-from .gk_solver_extension import GKConverter
+import os
 from typing import List
+from .gk_solver_extension import GKConverter
 
 
 def solver_extension_pyomo(self, disp=True):
@@ -362,18 +363,16 @@ class PyomoConverter(GKConverter):
             self._solver.options[data[0]] = data[1]
     
 
-    def solve(self):
+    def solve(self, disp=True) -> None:
         """
         solve the pyomo model
         """
         # solve the model
+        output_file = os.path.join(self._gekko_model._path, "output.txt")
         try:
-            results = self._solver.solve(self._pyomo_model, tee=True)
+            results = self._solver.solve(self._pyomo_model, tee=disp, logfile=output_file)
         except Exception as e:
             raise Exception("@error: Pyomo: %s" % e) from e
-
-        # reset stdout
-        self.solve_complete()
         
         # check the results
         solver_status = results.solver.status


### PR DESCRIPTION
Fixes a problem with stdout redirection that occured with multithreading:

- `sys.stdout` being modified globally meant that each individual thread would write to the same location, rather than individual `output.txt` files for the model's `_path`. There is no way to modify sys.stdout locally.
- this would also run into errors as `output.txt` closes after the solve (ie. tries to close twice when using 2 threads)

Instead of a catch-all solution, I have opted for using pyomo's `logfile` and amplpy's `OutputHandler` features to redirect stdout on a case-by-case basis.